### PR TITLE
Implemented gRPC binding for `getDataAtPar` method

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -803,8 +803,7 @@ object BlockAPI {
 
   def getDataAtPar[F[_]: Concurrent: EngineCell: Log: SafetyOracle: BlockStore](
       par: Par,
-      blockHash: String,
-      usePreStateHash: Boolean
+      blockHash: String
   ): F[ApiErr[(Seq[Par], LightBlockInfo)]] = {
 
     def casperResponse(

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -61,6 +61,14 @@ object DeployRuntime {
       }.map(kp("")).value
     }
 
+  def getDataAtPar[F[_]: Sync: DeployService](
+      par: Par,
+      blockHash: String
+  ): F[Unit] =
+    gracefulExit {
+      EitherT(DeployService[F].getDataAtPar(DataAtParQuery(blockHash, par))).map(kp("")).value
+    }
+
   def findDeploy[F[_]: Functor: Sync: Time: DeployService](
       deployId: Array[Byte]
   ): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -66,7 +66,7 @@ object DeployRuntime {
       blockHash: String
   ): F[Unit] =
     gracefulExit {
-      EitherT(DeployService[F].getDataAtPar(DataAtParQuery(blockHash, par))).map(kp("")).value
+      EitherT(DeployService[F].getDataAtPar(DataAtParQuery(par, blockHash))).map(kp("")).value
     }
 
   def findDeploy[F[_]: Functor: Sync: Time: DeployService](

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -2,12 +2,12 @@ package coop.rchain.casper.util.comm
 
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.protocol.deploy.v1.DeployServiceV1GrpcMonix
 import coop.rchain.crypto.signatures.Signed
+import coop.rchain.models.Par
 import coop.rchain.models.either.implicits._
 import coop.rchain.monix.Monixable
 import coop.rchain.shared.syntax._
@@ -26,6 +26,7 @@ trait DeployService[F[_]] {
   def listenForContinuationAtName(
       request: ContinuationAtNameQuery
   ): F[Either[Seq[String], Seq[ContinuationsWithBlockInfo]]]
+  def getDataAtPar(request: DataAtParQuery): F[Either[Seq[String], (Seq[Par], LightBlockInfo)]]
   def lastFinalizedBlock: F[Either[Seq[String], String]]
   def isFinalized(q: IsFinalizedQuery): F[Either[Seq[String], String]]
   def bondStatus(q: BondStatusQuery): F[Either[Seq[String], String]]
@@ -142,6 +143,17 @@ class GrpcDeployService[F[_]: Monixable: Sync](host: String, port: Int, maxMessa
       .toEitherF(
         _.message.error,
         _.message.payload.map(_.blockResults)
+      )
+
+  def getDataAtPar(
+      request: DataAtParQuery
+  ): F[Either[Seq[String], (Seq[Par], LightBlockInfo)]] =
+    stub
+      .getDataAtPar(request)
+      .fromTask
+      .toEitherF(
+        _.message.error,
+        _.message.payload.map(r => (r.par, r.block))
       )
 
   def lastFinalizedBlock: F[Either[Seq[String], String]] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/ListenAtPar.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/ListenAtPar.scala
@@ -1,0 +1,28 @@
+package coop.rchain.casper.util.comm
+
+import coop.rchain.models.GUnforgeable.UnfInstance.{GDeployIdBody, GDeployerIdBody, GPrivateBody}
+import coop.rchain.models.syntax.modelsSyntaxString
+import coop.rchain.models.{GDeployId, GDeployerId, GPrivate, GUnforgeable, Par}
+
+object ListenAtPar {
+  sealed trait Name
+  final case class UnforgPrivate(data: String)  extends Name
+  final case class UnforgDeploy(data: String)   extends Name
+  final case class UnforgDeployer(data: String) extends Name
+
+  def create(name: String, data: String): Option[Name] =
+    name match {
+      case "UnforgPrivate"  => Some(UnforgPrivate(data))
+      case "UnforgDeploy"   => Some(UnforgDeploy(data))
+      case "UnforgDeployer" => Some(UnforgDeployer(data))
+      case _                => None
+    }
+
+  def toPar(name: Name): Par = Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(name))))
+
+  private def unforgToUnforgProto(name: Name): GUnforgeable.UnfInstance = name match {
+    case UnforgPrivate(data)  => GPrivateBody(GPrivate(data.unsafeHexToByteString))
+    case UnforgDeploy(data)   => GDeployIdBody(GDeployId(data.unsafeHexToByteString))
+    case UnforgDeployer(data) => GDeployerIdBody(GDeployerId(data.unsafeHexToByteString))
+  }
+}

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -52,7 +52,6 @@ message DataAtNameQuery {
 message DataAtParQuery {
   string blockHash     = 1;
   Par par              = 2 [(scalapb.field).no_box = true];
-  bool usePreStateHash = 3;
 }
 
 message ContinuationAtNameQuery {

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -49,6 +49,12 @@ message DataAtNameQuery {
   Par name = 2;
 }
 
+message DataAtParQuery {
+  string blockHash     = 1;
+  Par par              = 2 [(scalapb.field).no_box = true];
+  bool usePreStateHash = 3;
+}
+
 message ContinuationAtNameQuery {
   int32 depth = 1;
   repeated Par names = 2;

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -50,8 +50,8 @@ message DataAtNameQuery {
 }
 
 message DataAtParQuery {
-  string blockHash     = 1;
-  Par par              = 2 [(scalapb.field).no_box = true];
+  Par par              = 1 [(scalapb.field).no_box = true];
+  string blockHash     = 2;
 }
 
 message ContinuationAtNameQuery {

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -14,6 +14,7 @@ import "DeployServiceCommon.proto";
 // make a scalapb directory in this file's location and place it inside
 
 import "scalapb/scalapb.proto";
+import "RhoTypes.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -43,6 +44,8 @@ service DeployService {
   rpc getBlocks(BlocksQuery) returns (stream BlockInfoResponse) {}
   // Find data sent to a name.
   rpc listenForDataAtName(DataAtNameQuery) returns (ListeningNameDataResponse) {}
+  // Find data sent to a par.
+  rpc getDataAtPar(DataAtParQuery) returns (ListeningParDataResponse) {}
   // Find processes receiving on a name.
   rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (ContinuationAtNameResponse) {}
   // Find block containing a deploy.
@@ -131,6 +134,19 @@ message ListeningNameDataResponse {
 message ListeningNameDataPayload {
   repeated DataWithBlockInfo blockInfo = 1;
   int32 length                         = 2;
+}
+
+// listenForDataAtPar
+message ListeningParDataResponse {
+  oneof message {
+    ServiceError error               = 1;
+    ListeningParDataPayload payload  = 2;
+  }
+}
+
+message ListeningParDataPayload {
+  repeated Par par     = 1;
+  LightBlockInfo block = 2 [(scalapb.field).no_box = true];
 }
 
 // listenForContinuationAtName

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -217,8 +217,10 @@ object Main {
       case Some(options.bondStatus)           => BondStatus(options.bondStatus.validatorPublicKey())
       case Some(options.dataAtName)           => DataAtName(options.dataAtName.name())
       case Some(options.contAtName)           => ContAtName(options.contAtName.name())
-      case Some(options.status)               => Status
-      case _                                  => Help
+      case Some(options.dataAtPar) =>
+        DataAtPar(options.dataAtPar.name(), options.dataAtPar.blockHash())
+      case Some(options.status) => Status
+      case _                    => Help
     }
 
   private def decryptKeyFromCon[F[_]: Sync: ConsoleIO](

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import cats.Parallel
 import cats.effect._
 import cats.syntax.all._
+import coop.rchain.casper.util.comm.ListenAtPar.toPar
 import coop.rchain.casper.util.comm._
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.PrivateKey
@@ -165,15 +166,16 @@ object Main {
       case ShowBlocks(depth)            => DeployRuntime.getBlocks[F](depth)
       case VisualizeDag(depth, showJustificationLines) =>
         DeployRuntime.visualizeDag[F](depth, showJustificationLines)
-      case MachineVerifiableDag  => DeployRuntime.machineVerifiableDag[F]
-      case DataAtName(name)      => DeployRuntime.listenForDataAtName[F](name)
-      case ContAtName(names)     => DeployRuntime.listenForContinuationAtName[F](names)
-      case Keygen(path)          => generateKey(path)
-      case LastFinalizedBlock    => DeployRuntime.lastFinalizedBlock[F]
-      case IsFinalized(hash)     => DeployRuntime.isFinalized[F](hash)
-      case BondStatus(publicKey) => DeployRuntime.bondStatus[F](publicKey)
-      case Status                => DeployRuntime.status[F]
-      case _                     => Sync[F].delay(options.printHelp())
+      case MachineVerifiableDag       => DeployRuntime.machineVerifiableDag[F]
+      case DataAtName(name)           => DeployRuntime.listenForDataAtName[F](name)
+      case ContAtName(names)          => DeployRuntime.listenForContinuationAtName[F](names)
+      case DataAtPar(name, blockHash) => DeployRuntime.getDataAtPar[F](toPar(name), blockHash)
+      case Keygen(path)               => generateKey(path)
+      case LastFinalizedBlock         => DeployRuntime.lastFinalizedBlock[F]
+      case IsFinalized(hash)          => DeployRuntime.isFinalized[F](hash)
+      case BondStatus(publicKey)      => DeployRuntime.bondStatus[F](publicKey)
+      case Status                     => DeployRuntime.status[F]
+      case _                          => Sync[F].delay(options.printHelp())
     }
 
     Sync[F].delay(

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -185,7 +185,7 @@ object DeployGrpcServiceV1 {
       ): Task[ListeningParDataResponse] =
         defer(
           BlockAPI
-            .getDataAtPar[F](request.par, request.blockHash, request.usePreStateHash)
+            .getDataAtPar[F](request.par, request.blockHash)
         ) { r =>
           import ListeningParDataResponse.Message
           import ListeningParDataResponse.Message._

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -180,6 +180,22 @@ object DeployGrpcServiceV1 {
           )
         }
 
+      def getDataAtPar(
+          request: DataAtParQuery
+      ): Task[ListeningParDataResponse] =
+        defer(
+          BlockAPI
+            .getDataAtPar[F](request.par, request.blockHash, request.usePreStateHash)
+        ) { r =>
+          import ListeningParDataResponse.Message
+          import ListeningParDataResponse.Message._
+          ListeningParDataResponse(
+            r.fold[Message](
+              Error, { case (par, block) => Payload(ListeningParDataPayload(par, block)) }
+            )
+          )
+        }
+
       def listenForContinuationAtName(
           request: ContinuationAtNameQuery
       ): Task[ContinuationAtNameResponse] =

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -108,7 +108,7 @@ object WebApi {
 
     def getDataAtPar(req: DataAtNameByBlockHashRequest): F[RhoDataResponse] =
       BlockAPI
-        .getDataAtPar(toPar(req), req.blockHash, req.usePreStateHash)
+        .getDataAtPar(toPar(req), req.blockHash)
         .flatMap(_.liftToBlockApiErr)
         .map(toRhoDataResponse)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -1,8 +1,9 @@
 package coop.rchain.node.configuration.commandline
 
 import java.nio.file.{Path, Paths}
-
 import coop.rchain.casper.util.comm.ListenAtName.{Name, PrivName, PubName}
+import coop.rchain.casper.util.comm.ListenAtPar
+import coop.rchain.casper.util.comm.ListenAtPar._
 import coop.rchain.comm.PeerNode
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.crypto.{PrivateKey, PublicKey}
@@ -740,6 +741,56 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   addSubcommand(dataAtName)
   addSubcommand(contAtName)
+
+  val dataAtPar = new Subcommand("data-at-par") {
+    descr(
+      "Get data at par"
+    )
+    helpWidth(width)
+
+    val blockHash =
+      opt[String](required = true, descr = "the hash value of the block", name = "block-hash")
+
+    val content = opt[String](
+      required = true,
+      descr = "data for the provided type",
+      name = "content",
+      short = 'c'
+    )
+
+    // TODO: To match the code, you should use the solution from here
+    //  https://stackoverflow.com/questions/12078366/can-i-get-a-compile-time-list-of-all-of-the-case-objects-which-derive-from-a-sea
+    val allowedTypes = "UnforgPrivate, UnforgDeploy, UnforgDeployer"
+
+    val nameType =
+      opt[String](
+        required = true,
+        descr = s"Type of the specified name (one of $allowedTypes)",
+        name = "type",
+        short = 't'
+      )
+
+    def dataAtParConverter(nameF: () => String, dataF: () => String, argType0: ArgType.V) =
+      new ValueConverter[ListenAtPar.Name] {
+        override def parse(
+            s: List[(String, List[String])]
+        ): Either[String, Option[ListenAtPar.Name]] = {
+          val name = create(nameF(), dataF())
+          Either.cond(
+            name.isDefined,
+            name,
+            s"Unknown type of the specified name. Should be one of $allowedTypes"
+          )
+        }
+        override val argType: ArgType.V = argType0
+      }
+
+    implicit val conv =
+      dataAtParConverter(() => nameType.getOrElse(""), () => content.getOrElse(""), ArgType.SINGLE)
+
+    val name = opt[ListenAtPar.Name]()
+  }
+  addSubcommand(dataAtPar)
 
   val findDeploy = new Subcommand("find-deploy") {
     descr(

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -2,6 +2,7 @@ package coop.rchain.node.configuration
 
 import coop.rchain.casper.CasperConf
 import coop.rchain.casper.util.comm.ListenAtName.Name
+import coop.rchain.casper.util.comm.ListenAtPar
 import coop.rchain.comm.PeerNode
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.crypto.{PrivateKey, PublicKey}
@@ -122,4 +123,5 @@ final case class BondStatus(publicKey: PublicKey)                          exten
 final case object Help                                                     extends Command
 final case class DataAtName(name: Name)                                    extends Command
 final case class ContAtName(names: List[Name])                             extends Command
+final case class DataAtPar(name: ListenAtPar.Name, blockHash: String)      extends Command
 final case object Status                                                   extends Command


### PR DESCRIPTION
## Overview

Added support for method `getDataAtPar` from `gRPC`. This method allows getting deploy results more effectively than `getDataAtName` because doesn't use the `depth` parameter.

This method can be called via another node run as `gRPC` client. Example of call

```shell
./rnode data-at-par --block-hash <BLOCK_HASH_STRING> --content <CONTENT> --type <TYPE>
```
Where

* `<BLOCK_HASH_STRING>` - a hash string of block. Can be got from the output of `propose` command.
* `<CONTENT>` - the content of the command. For example, it is deploy signature string for deploys.
* `<TYPE>` - type of command. Can be one of UnforgPrivate, UnforgDeploy, UnforgDeployer.

### Notes

* Deploy should be done with such Rholang code
```
new return(`rho:rchain:deployId`) in { return!("data-at-par") }
```
* For now, the solution doesn't print any results to the console. This code produces the empty string. This is done in a similar way to the `listenForDataAtName` and `listenForContinuationAtName` methods. 
https://github.com/stanislavlyalin/rchain/blob/728f38436a2d5cb0c9ef991a2b717a200b1b896f/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala#L64-L70

* Please be noticed of CLI params descriptions.
* Look at `TODO` comment. Is it necessary?


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
